### PR TITLE
devcontainer: added batman to the video group

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,8 @@ RUN cd /tmp && \
     curl -L -o virtualgl.deb "https://downloads.sourceforge.net/project/virtualgl/3.1/virtualgl_3.1_$ARCH.deb" && \
     dpkg -i virtualgl.deb
 
+RUN usermod -aG video batman
+
 USER batman
 
 RUN cd $HOME && \


### PR DESCRIPTION
**Description**

In the devcontainer, added the batman user to the video group to use video devices (e.g., webcam). Currently, batman cannot open `/dev/video*`.



